### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,9 @@ function _set(value: any, path: Path, object: any): any {
   let reference = object;
 
   parsedPath.forEach((key, index) => {
+    if (isPrototypePolluted(key))
+      return;
+    
     if (index === parsedPath.length - 1) {
       reference[key] = value;
       return;
@@ -87,6 +90,10 @@ function _set(value: any, path: Path, object: any): any {
   });
 
   return object;
+}
+
+function isPrototypePolluted(key: string) {
+  return ['__proto__', 'constructor', 'prototype'].includes(key);
 }
 
 export const get = curry(_get);


### PR DESCRIPTION
https://huntr.dev/users/arjunshibu has fixed the Prototype Pollution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/deep/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/@blakek/deep/1/README.md

### User Comments:

### :bar_chart: Metadata *

`@blakek/deep` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40blakek%2Fdeep

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var deep = require("@blakek/deep")
var obj = {}
console.log("Before : " + {}.polluted);
deep.set('Yes! Its Polluted', '__proto__.polluted', obj);
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i @blakek/deep # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![blakek-deep-fix](https://user-images.githubusercontent.com/43996156/102888728-5a36ac80-447f-11eb-8c34-18133ff44ea0.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
